### PR TITLE
Switch language parameter from positional to keyword argument

### DIFF
--- a/content/posts/hypermodern-python-02-testing.md
+++ b/content/posts/hypermodern-python-02-testing.md
@@ -732,7 +732,7 @@ from . import __version__, wikipedia
 @click.version_option(version=__version__)
 def main(language):
     """The hypermodern Python project."""
-    data = wikipedia.random_page(language)
+    data = wikipedia.random_page(language=language)
 
     title = data["title"]
     extract = data["extract"]


### PR DESCRIPTION
I _think_ you'd have to specify the `language` keyword in order for `test_main_uses_specified_language` to pass.

Fantastic series btw!