### PR TITLE
Remove type hints from mypy function

### DIFF
--- a/content/posts/hypermodern-python-04-typing.md
+++ b/content/posts/hypermodern-python-04-typing.md
@@ -112,7 +112,7 @@ Add the following Nox session to type-check your source code with mypy:
 
 ```python
 @nox.session(python=["3.8", "3.7"])
-def mypy(session: Session) -> None:
+def mypy(session):
     args = session.posargs or locations
     install_with_constraints(session, "mypy")
     session.run("mypy", *args)


### PR DESCRIPTION
Incredibly small fix. `Session` is used as a type hint before it's imported.